### PR TITLE
chore(release): update release-please configuration

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,14 +1,14 @@
 {
+  "always-update": true,
   "packages": {
     ".": {
-      "release-type": "simple",
+      "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["README.md"],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false,
-      "initial-version": "0.0.1"
+      "prerelease": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Update release configuration to use node release type and
enable always-update flag. Remove initial version as it's
no longer needed with the new release type.