### PR TITLE
chore(package.json): bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-tags-action",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "update-tags-action",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-tags-action",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "jimeh",
   "type": "module",
   "private": true,


### PR DESCRIPTION
This should have been done by release-please on the release PR, but it 
was missed. This has caused release-please to get confused, hopefully 
this should resolve it.