### PR TITLE
ci: remove unnecessary dependency and add more checks for release-tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [check-dist]
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       major: ${{ steps.release-please.outputs.major }}
@@ -91,7 +90,7 @@ jobs:
 
   release-tags:
     runs-on: ubuntu-latest
-    needs: release-please
+    needs: [release-please, check-dist, lint, test]
     if: ${{ needs.release-please.outputs.release_created }}
     permissions:
       contents: write


### PR DESCRIPTION
Adjust the GitHub Actions workflow to improve the release process:
- Remove unnecessary 'check-dist' dependency from release-please
- Add multiple dependencies (check-dist, lint, test) to release-tags
  to ensure comprehensive checks before releasing