### PR TITLE
chore(vscode): configure prettier as default formatter for multiple file types

### DIFF
--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -1,5 +1,14 @@
 {
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
Adds Prettier as the default formatter for JavaScript, TypeScript,
JSON, and JSONC file types in VS Code settings.