### PR TITLE
chore(deps): update dependabot configuration to include minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     groups:
       actions-minor:
         update-types:
+          - major
           - minor
           - patch
   - package-ecosystem: npm
@@ -23,4 +24,5 @@ updates:
       npm-production:
         dependency-type: production
         update-types:
+          - minor
           - patch


### PR DESCRIPTION
Modify dependabot configuration to include minor updates for both
GitHub Actions and npm production dependencies. This ensures more
comprehensive dependency tracking and potential improvements.