### PR TITLE
chore(readme): tweak version numbering in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to move its own major and minor tags.
 
 ### Basic
 
-<!-- x-release-please-start-minor -->
+<!-- x-release-please-start-version -->
 
 ```yaml
 - uses: jimeh/update-tags-action@v2
@@ -38,8 +38,6 @@ to move its own major and minor tags.
       v2.2
 ```
 
-<!-- x-release-please-end -->
-
 ### Deriving Tags from Version
 
 Automatically derive major and minor tags from a semver version string:
@@ -47,8 +45,8 @@ Automatically derive major and minor tags from a semver version string:
 ```yaml
 - uses: jimeh/update-tags-action@v2
   with:
-    derive_from: v1.2.3
-    # Creates tags: v1, v1.2
+    derive_from: v2.2.1
+    # Creates tags: v2, v2.2
 ```
 
 With a custom template (major tag only):
@@ -56,9 +54,9 @@ With a custom template (major tag only):
 ```yaml
 - uses: jimeh/update-tags-action@v2
   with:
-    derive_from: v1.2.3
+    derive_from: v2.2.1
     derive_from_template: '{{prefix}}{{major}}'
-    # Creates tag: v1
+    # Creates tag: v2
 ```
 
 Combine derived tags with explicit tags:
@@ -66,10 +64,12 @@ Combine derived tags with explicit tags:
 ```yaml
 - uses: jimeh/update-tags-action@v2
   with:
-    derive_from: v1.2.3
+    derive_from: v2.2.1
     tags: latest
-    # Creates tags: latest, v1, v1.2
+    # Creates tags: latest, v2, v2.2
 ```
+
+<!-- x-release-please-end -->
 
 ### With Release Please
 
@@ -165,12 +165,15 @@ tag[:ref[:annotation]]
 
 **Per-tag refs** allow different tags to point to different commits:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 - uses: jimeh/update-tags-action@v2
   with:
     tags: |
       v1:main
-      v2:develop
+      v1.2:main
+      v1.3:develop
 ```
 
 **Per-tag annotations** allow different annotation messages for each tag:
@@ -200,11 +203,11 @@ Per-tag values override the global `ref` and `annotation` inputs:
   with:
     tags: |
       v1:main:Custom annotation for v1
-      v2
+      v1.2
     ref: develop
     annotation: Default annotation for tags without per-tag override
     # v1 -> main with "Custom annotation for v1"
-    # v2 -> develop with "Default annotation..."
+    # v1.2 -> develop with "Default annotation..."
 ```
 
 Annotations can contain colons (everything after the second colon is the
@@ -217,6 +220,8 @@ annotation):
       v1:main:Release: version 1.0.0
     # Annotation will be "Release: version 1.0.0"
 ```
+
+<!-- x-release-please-end -->
 
 ### Derive Template Syntax
 
@@ -240,6 +245,8 @@ Available placeholders:
 
 Use Handlebars `{{#if}}` blocks to include content only when a variable has a
 value. This is useful for optional components like prerelease or build metadata:
+
+<!-- x-release-please-start-version -->
 
 ```yaml
 - uses: jimeh/update-tags-action@v2
@@ -271,6 +278,8 @@ You can also use `{{#unless}}` for inverse logic:
       {{prefix}}{{major}}{{#unless prerelease}}-stable{{/unless}}
     # Creates tag: v1-stable (only for non-prerelease versions)
 ```
+
+<!-- x-release-please-end -->
 
 <!-- action-docs-outputs source="action.yml" -->
 


### PR DESCRIPTION
This should hopefully ensures all examples updates the version
referenceto update-tags-action, but not the other lower version strings
which are examples.